### PR TITLE
Return value for readEEPROM

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TMP117-Arduino
-version=1.0.0
+version=1.0.1
 author=Nils Minor <nilsminor@web.de>
 maintainer=Nils Minor <nilsminor@web.de>
 sentence=Full-featured Arduino compatible TMP117 driver

--- a/src/TMP117.cpp
+++ b/src/TMP117.cpp
@@ -286,6 +286,7 @@ uint16_t  TMP117::readEEPROM (uint8_t eeprom_nr) {
   }
   else {
     Serial.println("EEPROM is busy");
+    return 0;
   }
 }
 


### PR DESCRIPTION
`uint16_t  TMP117::readEEPROM (uint8_t eeprom_nr)` doesn't have an explicit return in the event that the EEPROM is busy. This makes newer compilers throw errors (as this is undefined behaviour). 0 seems to be the most innocent return value, but maybe the max uint16 might be better?