### PR TITLE
Use enum classes

### DIFF
--- a/examples/high_low_temperature_alert/high_low_temperature_alert.ino
+++ b/examples/high_low_temperature_alert/high_low_temperature_alert.ino
@@ -34,14 +34,14 @@ void setup() {
   Serial.begin(115200);
 
   tmp.init ( new_temperature );     // set callback function. will be called if there is new sensor data
-  tmp.setConvMode (CONTINUOUS);     // contious measurement, also ONESHOT or SHUTWDOWN possible
+  tmp.setConvMode (TMP117_CMODE::CONTINUOUS);     // contious measurement, also ONESHOT or SHUTWDOWN possible
 
 
   tmp.init ( new_temperature );
-  tmp.setConvTime (C15mS5);         // 1. setup C125mS+NOAVE = 15.5 mS measurement time
-  tmp.setAveraging (NOAVE);
+  tmp.setConvTime (TMP117_CONVT::C15mS5);         // 1. setup C125mS+NOAVE = 15.5 mS measurement time
+  tmp.setAveraging (TMP117_AVE::NOAVE);
   
-  tmp.setAlertMode(ALERT);          // use THERMAL or ALERT to activate alert feature
+  tmp.setAlertMode(TMP117_PMODE::ALERT);          // use THERMAL or ALERT to activate alert feature
   tmp.setAllertCallback ( temperature_allert, ALERT_PIN );
   tmp.setAllertTemperature (LOW_TEMPERATURE_ALERT, HIGH_TEMPERATURE_ALERT);      
 }

--- a/examples/prompt_interpreter/prompt_interpreter.ino
+++ b/examples/prompt_interpreter/prompt_interpreter.ino
@@ -37,10 +37,10 @@ void setup() {
   Serial.begin(115200);
 
   tmp.init ( NULL );                // no callback
-  tmp.setConvMode (CONTINUOUS);     // contious measurement, also ONESHOT or SHUTWDOWN possible
+  tmp.setConvMode (TMP117_CMODE::CONTINUOUS);     // contious measurement, also ONESHOT or SHUTWDOWN possible
 
-  tmp.setConvTime (C15mS5);         // 1. setup C125mS+NOAVE = 15.5 mS measurement time
-  tmp.setAveraging (NOAVE);     
+  tmp.setConvTime (TMP117_CONVT::C15mS5);         // 1. setup C125mS+NOAVE = 15.5 mS measurement time
+  tmp.setAveraging (TMP117_AVE::NOAVE);     
 }
 
 /************************* Infinite Loop Function **********************************/

--- a/examples/temperature_callback/temperature_callback.ino
+++ b/examples/temperature_callback/temperature_callback.ino
@@ -43,21 +43,21 @@ void setup() {
   pinMode (LED_BUILTIN, OUTPUT); 
 
   tmp.init ( new_temperature );     // set callback function. will be called if there is new sensor data
-  tmp.setConvMode (CONTINUOUS);     // contious measurement, also ONESHOT or SHUTWDOWN possible
+  tmp.setConvMode (TMP117_CMODE::CONTINUOUS);     // contious measurement, also ONESHOT or SHUTWDOWN possible
 
   uint8_t setup_nr = 3;             // select an example setup to see diffrent modes
   switch (setup_nr) {
-    case 1: tmp.setConvTime (C15mS5); // 1. setup C125mS+NOAVE = 15.5 mS measurement time
-            tmp.setAveraging (NOAVE);
+    case 1: tmp.setConvTime (TMP117_CONVT::C15mS5); // 1. setup C125mS+NOAVE = 15.5 mS measurement time
+            tmp.setAveraging (TMP117_AVE::NOAVE);
             break;
-    case 2: tmp.setConvTime (C125mS); // 2. setup C125mS+AVE8 = 125 mS measurement time
-            tmp.setAveraging (AVE8);
+    case 2: tmp.setConvTime (TMP117_CONVT::C125mS); // 2. setup C125mS+AVE8 = 125 mS measurement time
+            tmp.setAveraging (TMP117_AVE::AVE8);
             break;
-    case 3: tmp.setConvTime (C125mS); // 3. setup C500mS+AVE32 = 500 mS measurement time
-            tmp.setAveraging (AVE32);
+    case 3: tmp.setConvTime (TMP117_CONVT::C125mS); // 3. setup C500mS+AVE32 = 500 mS measurement time
+            tmp.setAveraging (TMP117_AVE::AVE32);
             break;
-    case 4: tmp.setConvTime (C4S);    // 4. setup C1S+AVE64 = 1000 mS measurement time
-            tmp.setAveraging (AVE64);
+    case 4: tmp.setConvTime (TMP117_CONVT::C4S);    // 4. setup C1S+AVE64 = 1000 mS measurement time
+            tmp.setAveraging (TMP117_AVE::AVE64);
             break;
     default: setup_nr = 1;
   }  

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TMP117-Arduino
-version=1.0.2
+version=1.0.3
 author=Nils Minor <nilsminor@web.de>
 maintainer=Nils Minor <nilsminor@web.de>
 sentence=Full-featured Arduino compatible TMP117 driver

--- a/src/TMP117.cpp
+++ b/src/TMP117.cpp
@@ -20,7 +20,7 @@ TMP117::TMP117 (uint8_t addr) {
   
   address = addr;
   alert_pin = -1;
-  alert_type = NOALERT;
+  alert_type = TMP117_ALERT::NOALERT;
   newDataCallback = NULL;
 }
 
@@ -29,10 +29,10 @@ TMP117::TMP117 (uint8_t addr) {
     @param   _newDataCallback   callback function will be called when new data is available
 */
 void TMP117::init ( void (*_newDataCallback) (void) ) {
-  setConvMode (CONTINUOUS);
-  setConvTime (C125mS);
-  setAveraging (AVE8);
-  setAlertMode (DATA);
+  setConvMode (TMP117_CMODE::CONTINUOUS);
+  setConvTime (TMP117_CONVT::C125mS);
+  setAveraging (TMP117_AVE::AVE8);
+  setAlertMode (TMP117_PMODE::DATA);
   setOffsetTemperature(0);    
   
   newDataCallback = _newDataCallback;
@@ -62,17 +62,17 @@ void TMP117::softReset ( void ) {
 */
 void      TMP117::setAlertMode ( TMP117_PMODE mode) {
   uint16_t reg_value = readConfig ();
-  if (mode == THERMAL) {
+  if (mode == TMP117_PMODE::THERMAL) {
     reg_value |= 1UL << 4;    // change to thermal mode
     reg_value &= ~(1UL << 2); // set pin as alert flag
     reg_value &= ~(1UL << 3); // alert pin low active
   }
-  else if (mode == ALERT) {
+  else if (mode == TMP117_PMODE::ALERT) {
     reg_value &= ~(1UL << 4); // change to alert mode
     reg_value &= ~(1UL << 2); // set pin as alert flag
     reg_value &= ~(1UL << 3); // alert pin low active
   } 
-  else if (mode == DATA) {
+  else if (mode ==TMP117_PMODE:: DATA) {
     reg_value |= 1UL << 2;    // set pin as data ready flag
   } 
   writeConfig ( reg_value );
@@ -113,7 +113,7 @@ void      TMP117::setAllertTemperature (double lowtemp, double hightemp) {
 void      TMP117::setConvMode ( TMP117_CMODE cmode) {
    uint16_t reg_value = readConfig ();
    reg_value &= ~((1UL << 11) | (1UL << 10));       // clear bits
-   reg_value = reg_value | ( cmode  & 0x03 ) << 10; // set bits   
+   reg_value = reg_value | ( static_cast<int>(cmode)  & 0x03 ) << 10; // set bits   
    writeConfig ( reg_value );
 }
 
@@ -125,7 +125,7 @@ void      TMP117::setConvMode ( TMP117_CMODE cmode) {
 void      TMP117::setConvTime ( TMP117_CONVT convtime ) {
   uint16_t reg_value = readConfig ();
   reg_value &= ~((1UL << 9) | (1UL << 8) | (1UL << 7));       // clear bits
-  reg_value = reg_value | ( convtime  & 0x07 ) << 7;          // set bits
+  reg_value = reg_value | ( static_cast<int>(convtime)  & 0x07 ) << 7;          // set bits
   writeConfig ( reg_value );
 }
 /*!
@@ -136,7 +136,7 @@ void      TMP117::setConvTime ( TMP117_CONVT convtime ) {
 void      TMP117::setAveraging ( TMP117_AVE ave ) {
   uint16_t reg_value = readConfig ();
   reg_value &= ~((1UL << 6) | (1UL << 5) );       // clear bits
-  reg_value = reg_value | ( ave & 0x03 ) << 5;          // set bits
+  reg_value = reg_value | ( static_cast<int>(ave) & 0x03 ) << 5;          // set bits
   writeConfig ( reg_value );
 }
 
@@ -181,13 +181,13 @@ uint16_t  TMP117::readConfig (void) {
     newDataCallback ();
 
   if (reg_value >> 15 & 1UL) {
-    alert_type = HIGHALERT;
+    alert_type = TMP117_ALERT::HIGHALERT;
   }
   else if (reg_value >> 14 & 1UL) {
-    alert_type = LOWALERT;
+    alert_type = TMP117_ALERT::LOWALERT;
   }
   else {
-    alert_type = NOALERT;
+    alert_type = TMP117_ALERT::NOALERT;
   }
   
   //printConfig ( reg_value );

--- a/src/TMP117.h
+++ b/src/TMP117.h
@@ -63,11 +63,11 @@ typedef void (*allert_callback)(void);
         7             16s     16s     16s      16s    C16S
 */
 
-enum TMP117_PMODE     {THERMAL = 0, ALERT, DATA};                                 //!<  Pin mode 
-enum TMP117_CMODE     {CONTINUOUS = 0, SHUTDOWN = 1, ONESHOT = 3};                //!<  Conversion mode 
-enum TMP117_CONVT     {C15mS5 = 0, C125mS, C250mS, C500mS, C1S, C4S, C8S, C16S};  //!<  Conversion time
-enum TMP117_AVE       {NOAVE = 0, AVE8, AVE32, AVE64};                            //!<  Averaging mode
-enum TMP117_ALERT     {NOALERT = 0, HIGHALERT, LOWALERT};                         //!<  Alert type 
+enum class TMP117_PMODE     {THERMAL = 0, ALERT, DATA};                                 //!<  Pin mode 
+enum class TMP117_CMODE     {CONTINUOUS = 0, SHUTDOWN = 1, ONESHOT = 3};                //!<  Conversion mode 
+enum class TMP117_CONVT     {C15mS5 = 0, C125mS, C250mS, C500mS, C1S, C4S, C8S, C16S};  //!<  Conversion time
+enum class TMP117_AVE       {NOAVE = 0, AVE8, AVE32, AVE64};                            //!<  Averaging mode
+enum class TMP117_ALERT     {NOALERT = 0, HIGHALERT, LOWALERT};                         //!<  Alert type 
 
 class TMP117 {
 


### PR DESCRIPTION
This commit modifies the enums to use enum classes, which will prevent naming clashes when using this with other libraries